### PR TITLE
[fix] cmux_vcom_read called in muiti-thread may cause hardfault

### DIFF
--- a/inc/cmux.h
+++ b/inc/cmux.h
@@ -57,6 +57,12 @@ struct cmux_vcoms
     rt_uint8_t link_port;                                 /* link port id */
 
     rt_bool_t frame_using_status;                         /* This is designed for long frame when we read data; the flag will be "1" when long frame haven't reading done */
+
+    struct cmux_frame *frame;
+
+    rt_size_t length;
+
+    rt_uint8_t *data;
 };
 
 struct cmux


### PR DESCRIPTION
在多个线程中调用到`cmux_vcom_read`函数，例如1个ppp接收线程，1个at接收线程，可能会导致内部几个static变量异常，可能触发以下一些`rt_free`的断言
```c
RT_ASSERT((((rt_ubase_t)rmem) & (RT_ALIGN_SIZE - 1)) == 0);
```
```c
RT_ASSERT(mem->used);
```