### PR TITLE
完善 CMUX 1.1.0 版本

### DIFF
--- a/inc/cmux.h
+++ b/inc/cmux.h
@@ -17,10 +17,17 @@
 extern "C" {
 #endif
 
-#define CMUX_BUFFER_SIZE   2048
+//#define CMUX_DEBUG
 
-#define CMUX_SW_VERSION           "1.0.0"
-#define CMUX_SW_VERSION_NUM       0x10000
+/* CMUX using long frame mode by default */
+#define CMUX_RECV_READ_MAX 2048
+
+#ifndef CMUX_BUFFER_SIZE
+#define CMUX_BUFFER_SIZE   (CMUX_RECV_READ_MAX * 2)
+#endif
+
+#define CMUX_SW_VERSION           "1.1.0"
+#define CMUX_SW_VERSION_NUM       0x10100
 
 struct cmux_buffer
 {
@@ -97,6 +104,8 @@ rt_err_t cmux_start(struct cmux *object);
 rt_err_t cmux_stop(struct cmux *object);
 rt_err_t cmux_attach(struct cmux *object, int port, const char *alias_name, rt_uint16_t flags, void *user_data);
 rt_err_t cmux_detach(struct cmux *object, const char *alias_name);
+void cmux_at_cmd_cfg(uint8_t mode, uint8_t subset, uint32_t port_speed, uint32_t N1, uint32_t T1, uint32_t N2,
+        uint32_t T2, uint32_t T3, uint32_t k);
 
 /* cmux_utils */
 rt_uint8_t cmux_frame_check(const rt_uint8_t *input, int length);

--- a/src/gsm/cmux_gsm.c
+++ b/src/gsm/cmux_gsm.c
@@ -24,17 +24,67 @@
 #endif
 #include <rtdbg.h>
 
+/**
+ * +CMUX=<mode>[,<subset>[,<port_speed>[,<N1>[,<T1>[,<N2>[,<T2>[,<T3>[,<k>]]]]]]]]
+ * port_speed:
+ * 1 9600
+   2 19200
+   3 38400
+   4 57600
+   5 115200
+   6 230400
+   7 460800
+   8 921600
+ *
+ */
 #ifndef CMUX_CMD
 #define CMUX_CMD "AT+CMUX=0,0,5,2048,20,3,30,10,2"
 #endif
 
-struct cmux *gsm = RT_NULL;
+static struct cmux *gsm = RT_NULL;
+static char cmux_cmd[64] = { CMUX_CMD };
 
-static const struct modem_chat_data cmd[] =
+static struct modem_chat_data cmd[] =
 {
     {"AT",              MODEM_CHAT_RESP_OK,              10, 1, RT_FALSE},
-    {CMUX_CMD,          MODEM_CHAT_RESP_OK,               5, 1, RT_FALSE},
+    {cmux_cmd,          MODEM_CHAT_RESP_OK,               5, 1, RT_FALSE},
 };
+
+/**
+ * configuration the AT+CMUX command parameter
+ *
+ * default @see CMUX_CMD
+ *
+ * @param mode 0 Basic option, 1 Advanced option
+ * @param subset 0 UIH frames used only, 1 UI frames used only, 2 I frames used only
+ * @param port_speed serial port speed, like 115200
+ * @param N1 maximum frame size
+ * @param T1 acknowledgement timer in units of ten milliseconds
+ * @param N2 maximum number of re-transmissions
+ * @param T2 response timer for the multiplexer control channel in units of ten milliseconds, T2 must be longer than T1
+ * @param T3 wake up response timer in seconds
+ * @param k window size, for Advanced operation with Error Recovery options
+ */
+void cmux_at_cmd_cfg(uint8_t mode, uint8_t subset, uint32_t port_speed, uint32_t N1, uint32_t T1, uint32_t N2,
+        uint32_t T2, uint32_t T3, uint32_t k)
+{
+    RT_ASSERT(T2 > T1);
+    switch(port_speed)
+    {
+        case 9600: port_speed = 1; break;
+        case 19200: port_speed = 2; break;
+        case 38400: port_speed = 3; break;
+        case 57600: port_speed = 4; break;
+        case 115200: port_speed = 5; break;
+        case 230400: port_speed = 6; break;
+        case 460800: port_speed = 7; break;
+        case 921600: port_speed = 8; break;
+        default: RT_ASSERT("Not support port speed" && 0);
+    }
+
+    rt_snprintf(cmux_cmd, sizeof(cmux_cmd), "AT+CMUX=%d,%d,%d,%d,%d,%d,%d,%d,%d", mode, subset, port_speed, N1, T1, N2, T2,
+            T3, k);
+}
 
 static rt_err_t cmux_at_command(struct rt_device *device)
 {
@@ -50,7 +100,13 @@ static rt_err_t cmux_gsm_start(struct cmux *obj)
     struct rt_device *device = RT_NULL;
 
     device = obj->dev;
-    result = rt_device_open(device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX);
+    /* using DMA mode first */
+    result = rt_device_open(device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_DMA_RX);
+    /* result interrupt mode when DMA mode not supported */
+    if (result == -RT_EIO)
+    {
+        result = rt_device_open(device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX);
+    }
     if(result != RT_EOK)
     {
         LOG_E("cmux can't open %s.", device->parent.name);


### PR DESCRIPTION
- 【增加】CMUX 长帧（2048）模式，并默认启用，保证 http/https 测试通过，内存会有所增加
- 【增加】对于串口 DMA 接收模式的支持
- 【增加】cmux_at_cmd_cfg API ，便于应用层对 CMUX 后的波特率进行修改，默认为 115200